### PR TITLE
Hacked some stuff together

### DIFF
--- a/src/Iodine/Runtime/IodineContract.cs
+++ b/src/Iodine/Runtime/IodineContract.cs
@@ -66,7 +66,7 @@ namespace Iodine.Runtime
 
         public override string ToString ()
         {
-            return string.Format ("<Interface {0}>", Name);
+            return string.Format ("<Contract {0}>", Name);
         }
     }
 }

--- a/src/Iodine/Runtime/IodineTrait.cs
+++ b/src/Iodine/Runtime/IodineTrait.cs
@@ -66,6 +66,10 @@ namespace Iodine.Runtime
                     IodineMethod objMethod = attr as IodineMethod;
 
                     if (objMethod == null) {
+                        // HACK: Make builtin methods work
+                        if (attr is BuiltinMethodCallback) {
+                            continue;
+                        }
                         if (attr is IodineBoundMethod) {
                             objMethod = ((IodineBoundMethod)attr).Method;
                         } else {

--- a/src/Iodine/Runtime/StandardTypes/IodineBytes.cs
+++ b/src/Iodine/Runtime/StandardTypes/IodineBytes.cs
@@ -66,6 +66,11 @@ namespace Iodine.Runtime
             SetAttribute ("rindex", new BuiltinMethodCallback (IndexOf, this));
             SetAttribute ("substr", new BuiltinMethodCallback (Substring, this));
             SetAttribute ("contains", new BuiltinMethodCallback (Contains, this));
+
+            // HACK: Add __iter__ attribute to match Iterable trait
+            SetAttribute ("__iter__", new BuiltinMethodCallback ((VirtualMachine vm, IodineObject self, IodineObject [] args) => {
+                return GetIterator (vm);
+            }, this));
         }
 
         public IodineBytes (byte[] val)

--- a/src/Iodine/Runtime/StandardTypes/IodineRange.cs
+++ b/src/Iodine/Runtime/StandardTypes/IodineRange.cs
@@ -46,6 +46,11 @@ namespace Iodine.Runtime
             this.end = max;
             this.step = step;
             this.min = min;
+
+            // HACK: Add __iter__ attribute to match Iterable trait
+            SetAttribute ("__iter__", new BuiltinMethodCallback ((VirtualMachine vm, IodineObject self, IodineObject [] args) => {
+                return GetIterator (vm);
+            }, this));
         }
 
         public override IodineObject GetIterator (VirtualMachine vm)

--- a/src/Iodine/Runtime/StandardTypes/IodineString.cs
+++ b/src/Iodine/Runtime/StandardTypes/IodineString.cs
@@ -85,6 +85,11 @@ namespace Iodine.Runtime
             SetAttribute ("isSymbol", new BuiltinMethodCallback (IsSymbol, this));
             SetAttribute ("ljust", new BuiltinMethodCallback (PadRight, this));
             SetAttribute ("rjust", new BuiltinMethodCallback (PadLeft, this));
+
+            // HACK: Add __iter__ attribute to match Iterable trait
+            SetAttribute ("__iter__", new BuiltinMethodCallback ((VirtualMachine vm, IodineObject self, IodineObject [] args) => {
+                return GetIterator (vm);
+            }, this));
         }
 
         public override bool Equals (IodineObject obj)

--- a/src/Iodine/Runtime/StandardTypes/IodineTuple.cs
+++ b/src/Iodine/Runtime/StandardTypes/IodineTuple.cs
@@ -62,6 +62,11 @@ namespace Iodine.Runtime
             : base (TypeDefinition)
         {
             Objects = items;
+
+            // HACK: Add __iter__ attribute to match Iterable trait
+            SetAttribute ("__iter__", new BuiltinMethodCallback ((VirtualMachine vm, IodineObject self, IodineObject [] args) => {
+                return GetIterator (vm);
+            }, this));
         }
 
         public override bool Equals (object obj)


### PR DESCRIPTION
- Added __iter__ attributes so they can be seen from within Iodine
sources
- Changed "Interface" to "Contract" in the Contract string
representation
- Hacked trait matching to work with runtime-provided types