### PR TITLE
Improved handling of truthy/falsey values

### DIFF
--- a/modules/testing.id
+++ b/modules/testing.id
@@ -238,9 +238,8 @@ class Test {
 
 func describe(name, block) {
     results = _describe(name, block, 1);
-    failures = filter(results, lambda(result) => results[result] != null);
-
-    if (len(failures) > 0) {
+    failures = filter(results, lambda(result) => results[result [0]] isnot Null);
+    if (failures isnot Null && len(failures) > 0) {
         print('Tests failed!');
         sys.exit(len(failures));
     }

--- a/src/Iodine/Properties/AssemblyInfo.cs
+++ b/src/Iodine/Properties/AssemblyInfo.cs
@@ -46,7 +46,7 @@ using System.Runtime.CompilerServices;
 // The form "{Major}.{Minor}.*" will automatically update the build and revision,
 // and "{Major}.{Minor}.{Build}.*" will update just the revision.
 
-[assembly: AssemblyVersion ("0.11.0.*")]
+[assembly: AssemblyVersion ("0.11.1.*")]
 
 // The following attributes are used to specify the signing key for the assembly,
 // if desired. See the Mono documentation for more information about signing.

--- a/src/Iodine/Runtime/StandardTypes/IodineBigInt.cs
+++ b/src/Iodine/Runtime/StandardTypes/IodineBigInt.cs
@@ -282,7 +282,7 @@ namespace Iodine.Runtime
 
         public override bool IsTrue ()
         {
-            return Value != 0;
+            return Value > 0;
         }
 
         public override string ToString ()

--- a/src/Iodine/Runtime/StandardTypes/IodineFloat.cs
+++ b/src/Iodine/Runtime/StandardTypes/IodineFloat.cs
@@ -227,6 +227,11 @@ namespace Iodine.Runtime
             return false;
         }
 
+        public override bool IsTrue ()
+        {
+            return Value > 0.0f;
+        }
+
         public override string ToString ()
         {
             return Value.ToString ();

--- a/src/Iodine/Runtime/StandardTypes/IodineFloat.cs
+++ b/src/Iodine/Runtime/StandardTypes/IodineFloat.cs
@@ -35,6 +35,7 @@ namespace Iodine.Runtime
     public class IodineFloat : IodineObject
     {
         public static readonly IodineTypeDefinition TypeDefinition = new FloatTypeDef ();
+        public static readonly IodineFloat Epsilon = new IodineFloat (double.Epsilon);
 
         class FloatTypeDef : IodineTypeDefinition
         {
@@ -66,7 +67,7 @@ namespace Iodine.Runtime
             IodineFloat floatVal = obj as IodineFloat;
 
             if (floatVal != null) {
-                return floatVal.Value == Value;
+                return Math.Abs (floatVal.Value - Value) < double.Epsilon;
             }
 
             return false;
@@ -140,7 +141,7 @@ namespace Iodine.Runtime
                     "Right hand value expected to be of type Float"));
                 return null;
             }
-            return IodineBool.Create (Value == floatVal);
+            return IodineBool.Create (Math.Abs (Value - floatVal) < double.Epsilon);
         }
 
         public override IodineObject NotEquals (VirtualMachine vm, IodineObject right)
@@ -151,7 +152,7 @@ namespace Iodine.Runtime
                     "Right hand value expected to be of type Float"));
                 return null;
             }
-            return IodineBool.Create (Value != floatVal);
+            return IodineBool.Create (Math.Abs (Value - floatVal) > double.Epsilon);
         }
 
 

--- a/src/Iodine/Runtime/StandardTypes/IodineInteger.cs
+++ b/src/Iodine/Runtime/StandardTypes/IodineInteger.cs
@@ -391,7 +391,7 @@ namespace Iodine.Runtime
 
         public override bool IsTrue ()
         {
-            return Value != 0;
+            return Value > 0;
         }
 
         public override string ToString ()

--- a/src/Iodine/Runtime/StandardTypes/IodineList.cs
+++ b/src/Iodine/Runtime/StandardTypes/IodineList.cs
@@ -537,7 +537,12 @@ namespace Iodine.Runtime
                 return new IodineInteger (-1);
             }
             return new IodineInteger (Objects.FindLastIndex (o => o.Equals (item)));
-        } 
+        }
+
+        public override bool IsTrue ()
+        {
+            return Objects.Count > 0;
+        }
 
         public override int GetHashCode ()
         {

--- a/src/Iodine/Runtime/StandardTypes/IodineNull.cs
+++ b/src/Iodine/Runtime/StandardTypes/IodineNull.cs
@@ -50,6 +50,11 @@ namespace Iodine.Runtime
 
         }
 
+        public override bool IsTrue ()
+        {
+            return false;
+        }
+
         public override string ToString ()
         {
             return "null";

--- a/src/Iodine/Runtime/StandardTypes/IodineString.cs
+++ b/src/Iodine/Runtime/StandardTypes/IodineString.cs
@@ -688,6 +688,11 @@ namespace Iodine.Runtime
 
             return new IodineString (Value.PadLeft ((int)width.Value, ch));
         }
+
+        public override bool IsTrue ()
+        {
+            return Value.Length > 0;
+        }
     }
 }
 

--- a/src/Iodine/Runtime/StandardTypes/IodineTuple.cs
+++ b/src/Iodine/Runtime/StandardTypes/IodineTuple.cs
@@ -193,6 +193,11 @@ namespace Iodine.Runtime
             return new IodineString (String.Format ("({0})", repr));
         }
 
+        public override bool IsTrue ()
+        {
+            return Objects.Length > 0;
+        }
+
         public override int GetHashCode ()
         {
             return Objects.GetHashCode ();


### PR DESCRIPTION
- Made lists, tuple and strings be truthy if their length is above zero
- Made ints, bigints and floats be truthy if their value is above zero
- Made null always be falsey
- Improved float comparisons by using an epsilon value
- Incremented build number by one (v0.11.1)